### PR TITLE
Correção de anotações de passiva

### DIFF
--- a/documents/CP0019.conllu
+++ b/documents/CP0019.conllu
@@ -14,7 +14,7 @@
 8	actividades	actividade	NOUN	<np-idf>|N|F|P|@P<	Gender=Fem|Number=Plur	6	nmod	_	_
 9	passadas	passado	ADJ	<mv>|V|PCP|F|P|@ICL-N<	Gender=Fem|Number=Plur	8	amod	_	SpaceAfter=No
 10	,	,	PUNCT	PU|@PU	_	9	punct	_	_
-11	foram	ir	AUX	<aux>|V|PS|3P|IND|@FS-STA	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	12	aux	_	_
+11	foram	ser	AUX	<aux>|V|PS|3P|IND|@FS-STA	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	12	aux:pass	_	_
 12	identificadas	identificar	VERB	<mv>|V|PCP|F|P|@ICL-AUX<	Gender=Fem|Number=Plur|VerbForm=Part	0	root	_	_
 13	como	como	ADV	<prd>|ADV|@<SC	_	12	xcomp	_	_
 14	principais	principal	ADJ	ADJ|F|P|@>N	Gender=Fem|Number=Plur	15	amod	_	_

--- a/documents/CP0148.conllu
+++ b/documents/CP0148.conllu
@@ -100,7 +100,7 @@
 16-17	deles	_	_	_	_	_	_	_	_
 16	de	de	ADP	PRP|@N<	_	17	case	_	_
 17	eles	eles	PRON	<-sam>|PERS|M|3P|NOM|@P<	Case=Nom|Gender=Masc|Number=Plur|Person=3|PronType=Prs	15	nmod	_	_
-18	foram	ir	AUX	<aux>|V|PS|3P|IND|@FS-STA	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	19	aux	_	_
+18	foram	ser	AUX	<aux>|V|PS|3P|IND|@FS-STA	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	19	aux:pass	_	_
 19	ocupados	ocupar	VERB	<mv>|V|PCP|M|P|@ICL-AUX<	Gender=Masc|Number=Plur|VerbForm=Part|Voice=Pass	0	root	_	_
 20	por	por	ADP	PRP|@PASS	_	21	case	_	_
 21	imigrantes	imigrante	NOUN	<np-idf>|N|M|P|@P<	Gender=Masc|Number=Plur	19	obl:agent	_	_

--- a/documents/CP0149.conllu
+++ b/documents/CP0149.conllu
@@ -108,7 +108,7 @@
 # id = 769
 1	Importantes	importante	ADJ	ADJ|M|P|@>N	Gender=Masc|Number=Plur	2	amod	_	_
 2	reforços	reforço	NOUN	<np-idf>|N|M|P|@SUBJ>	Gender=Masc|Number=Plur	5	nsubj	_	_
-3	foram	ir	AUX	<aux>|V|PS|3P|IND|@FS-STA	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	5	aux	_	_
+3	foram	ser	AUX	<aux>|V|PS|3P|IND|@FS-STA	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	5	aux:pass	_	_
 4	já	já	ADV	ADV|@ADVL>	_	5	advmod	_	_
 5	enviados	enviar	VERB	<mv>|V|PCP|M|P|@ICL-AUX<	Gender=Masc|Number=Plur|VerbForm=Part	0	root	_	_
 6	para	para	ADP	PRP|@<SA	_	8	case	_	_

--- a/documents/CP0150.conllu
+++ b/documents/CP0150.conllu
@@ -125,7 +125,7 @@
 6	Miró	Miró	PROPN	PROP|M|S|@P<	Gender=Masc|Number=Sing	4	conj	_	_
 7	e	e	CCONJ	<co-prparg>|KC|@CO	_	8	cc	_	_
 8	Martinez	Martinez	PROPN	PROP|M|S|@P<	Gender=Masc|Number=Sing	4	conj	_	_
-9	foram	ir	AUX	<aux>|V|PS|3P|IND|@FS-STA	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	10	aux	_	_
+9	foram	ser	AUX	<aux>|V|PS|3P|IND|@FS-STA	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	10	aux:pass	_	_
 10	descobertas	descobrir	VERB	<mv>|V|PCP|F|P|@ICL-AUX<	Gender=Fem|Number=Plur|VerbForm=Part|Voice=Pass	0	root	_	_
 11	ontem	ontem	ADV	ADV|@<ADVL	_	10	advmod	_	SpaceAfter=No
 12	,	,	PUNCT	PU|@PU	_	10	punct	_	_

--- a/documents/CP0151.conllu
+++ b/documents/CP0151.conllu
@@ -55,7 +55,7 @@
 8	de	de	ADP	<sam->|PRP|@N<	_	10	case	_	_
 9	a	o	DET	<-sam>|<artd>|ART|@>N	Definite=Def|PronType=Art	10	det	_	_
 10	Luzostela	Luzostela	PROPN	PROP|F|S|@P<	Gender=Fem|Number=Sing	7	nmod	_	_
-11	foram	ir	AUX	<aux>|V|PS|3P|IND|@FS-STA	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	13	aux	_	_
+11	foram	ser	AUX	<aux>|V|PS|3P|IND|@FS-STA	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	13	aux:pass	_	_
 12	ontem	ontem	ADV	ADV|@ADVL>	_	13	advmod	_	_
 13	retirados	retirar	VERB	<mv>|V|PCP|M|P|@ICL-AUX<	Gender=Masc|Number=Plur|VerbForm=Part	0	root	_	_
 14-15	da	_	_	_	_	_	_	_	_

--- a/documents/CP0152.conllu
+++ b/documents/CP0152.conllu
@@ -136,7 +136,7 @@
 32	ministro	ministro	NOUN	<cjt>|<np-idf>|N|M|S|@N<PRED	Gender=Masc|Number=Sing	29	appos	_	_
 33	regional	regional	ADJ	ADJ|M|S|@N<	Gender=Masc|Number=Sing	32	amod	_	_
 34	--	--	PUNCT	PU|@PU	_	12	punct	_	_
-35	foram	ir	AUX	<aux>|V|PS|3P|IND|@FS-STA	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	36	aux	_	_
+35	foram	ser	AUX	<aux>|V|PS|3P|IND|@FS-STA	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	36	aux:pass	_	_
 36	forçados	forçar	VERB	<mv>|V|PCP|M|P|@ICL-AUX<	Gender=Masc|Number=Plur|VerbForm=Part	0	root	_	_
 37	a	a	SCONJ	PRP|@<PIV	_	38	mark	_	_
 38-39	demitir-se	_	_	_	_	_	_	_	_

--- a/documents/CP0173.conllu
+++ b/documents/CP0173.conllu
@@ -78,7 +78,7 @@
 1	Em	em	ADP	<sam->|PRP|@ADVL>	_	3	case	_	_
 2	a	o	DET	<-sam>|<artd>|ART|@>N	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	3	det	_	_
 3	operação	operação	NOUN	<np-def>|N|F|S|@P<	Gender=Fem|Number=Sing	5	obl	_	_
-4	foram	ir	AUX	<aux>|V|PS|3P|IND|@FS-STA	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	5	aux	_	_
+4	foram	ser	AUX	<aux>|V|PS|3P|IND|@FS-STA	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	5	aux:pass	_	_
 5	detectadas	detectar	VERB	<mv>|V|PCP|F|P|@ICL-AUX<	Gender=Fem|Number=Plur|VerbForm=Part	0	root	_	SpaceAfter=No
 6	,	,	PUNCT	PU|@PU	_	8	punct	_	_
 7	entre	entre	ADP	PRP|@>N	_	8	case	_	_

--- a/documents/CP0819.conllu
+++ b/documents/CP0819.conllu
@@ -43,7 +43,7 @@
 3	esse	esse	DET	<dem>|DET|M|S|@>N	Gender=Masc|Number=Sing|PronType=Dem	4	det	_	_
 4	direito	direito	NOUN	<np-def>|N|M|S|@SUBJ>	Gender=Masc|Number=Sing	8	nsubj	_	_
 5-6	foi-me	_	_	_	_	_	_	_	_
-5	foi	ir	AUX	<aux>|<hyphen>|V|PS|3S|IND|@FS-ACC>	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	aux	_	_
+5	foi	ser	AUX	<aux>|<hyphen>|V|PS|3S|IND|@FS-ACC>	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	aux:pass	_	_
 6	me	eu	PRON	<refl>|PERS|M/F|1S|DAT|@DAT>	Case=Dat|Number=Sing|Person=1|PronType=Prs	8	iobj	_	_
 7	sempre	sempre	ADV	ADV|@ADVL>	_	8	advmod	_	_
 8	negado	negar	VERB	<mv>|V|PCP|M|S|@ICL-AUX<	Gender=Masc|Number=Sing|VerbForm=Part	11	parataxis	_	SpaceAfter=No


### PR DESCRIPTION
PR relacionado ao issue #359, seguindo o que foi feito no commit 57b12f7 para o subconjunto da [query](http://match.grew.fr/?corpus=UD_Portuguese-Bosque@dev&custom=6172ffa178583&clustering=V.VerbForm) onde o AUX tem feature ```Tense=Past```